### PR TITLE
Scale up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *swp
 node_modules
+.idea
+.vagrant
+*.log
+package-lock.json

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+Vagrant.configure("2") do |config|
+  config.vm.define 'main' do |main|
+    main.vm.box = "ubuntu/xenial64"
+    main.vm.network "private_network", type: "dhcp"
+    main.vm.network :forwarded_port, guest: 80, host: 8000
+    main.vm.provision :shell, path: "bootstrap_main.sh"
+    config.vm.provider "virtualbox" do |v|
+        v.memory = 2048
+        v.cpus = 2
+    end
+  end
+  config.vm.define 'app_server_1' do |app_server_1|
+    app_server_1.vm.box = "ubuntu/xenial64"
+    app_server_1.vm.network "private_network", type: "dhcp"
+    app_server_1.vm.network :forwarded_port, guest: 3000, host: 3000
+    app_server_1.vm.provision :shell, path: "bootstrap_app.sh"
+    config.vm.provider "virtualbox" do |v|
+        v.memory = 2048
+        v.cpus = 2
+    end
+  end
+  config.vm.define 'app_server_2' do |app_server_2|
+    app_server_2.vm.box = "ubuntu/xenial64"
+    app_server_2.vm.network "private_network", type: "dhcp"
+    app_server_2.vm.network :forwarded_port, guest: 3010, host: 3010
+    app_server_2.vm.provision :shell, path: "bootstrap_app.sh"
+    config.vm.provider "virtualbox" do |v|
+        v.memory = 4096
+        v.cpus = 4
+    end
+  end
+end
+

--- a/app.js
+++ b/app.js
@@ -20,7 +20,9 @@ app.set('view engine', 'jade');
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-app.use(logger('dev'));
+if (app.get('env') === 'development') {
+    app.use(logger('dev'));
+}
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/bin/www
+++ b/bin/www
@@ -3,88 +3,102 @@
 /**
  * Module dependencies.
  */
+var cluster = require('cluster');
+var numCPUs = require('os').cpus().length;
 
-var app = require('../app');
-var debug = require('debug')('busyapi:server');
-var http = require('http');
-
-/**
- * Get port from environment and store in Express.
- */
-
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
-
-/**
- * Create HTTP server.
- */
-
-var server = http.createServer(app);
-
-/**
- * Listen on provided port, on all network interfaces.
- */
-
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
-
-/**
- * Normalize a port into a number, string, or false.
- */
-
-function normalizePort(val) {
-  var port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
+// https://nodejs.org/api/cluster.html#cluster_cluster
+if (cluster.isMaster) {
+  // Fork workers.
+  for (var i = 0; i < numCPUs; i++) {
+    cluster.fork();
   }
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`worker ${worker.process.pid} died`);
+  });
+} else {
 
-  if (port >= 0) {
-    // port number
-    return port;
-  }
+    var app = require('../app');
+    var debug = require('debug')('busyapi:server');
+    var http = require('http');
 
-  return false;
-}
+    /**
+     * Get port from environment and store in Express.
+     */
 
-/**
- * Event listener for HTTP server "error" event.
- */
+    var port = normalizePort(process.env.PORT || '3000');
+    app.set('port', port);
 
-function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
+    /**
+     * Create HTTP server.
+     */
 
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
+    var server = http.createServer(app);
 
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
-      process.exit(1);
-      break;
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
-}
+    /**
+     * Listen on provided port, on all network interfaces.
+     */
 
-/**
- * Event listener for HTTP server "listening" event.
- */
+    server.listen(port);
+    server.on('error', onError);
+    server.on('listening', onListening);
 
-function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+    /**
+     * Normalize a port into a number, string, or false.
+     */
+
+    function normalizePort(val) {
+      var port = parseInt(val, 10);
+
+      if (isNaN(port)) {
+        // named pipe
+        return val;
+      }
+
+      if (port >= 0) {
+        // port number
+        return port;
+      }
+
+      return false;
+    }
+
+    /**
+     * Event listener for HTTP server "error" event.
+     */
+
+    function onError(error) {
+      if (error.syscall !== 'listen') {
+        throw error;
+      }
+
+      var bind = typeof port === 'string'
+        ? 'Pipe ' + port
+        : 'Port ' + port;
+
+      // handle specific listen errors with friendly messages
+      switch (error.code) {
+        case 'EACCES':
+          console.error(bind + ' requires elevated privileges');
+          process.exit(1);
+          break;
+        case 'EADDRINUSE':
+          console.error(bind + ' is already in use');
+          process.exit(1);
+          break;
+        default:
+          throw error;
+      }
+    }
+
+    /**
+     * Event listener for HTTP server "listening" event.
+     */
+
+    function onListening() {
+      var addr = server.address();
+      var bind = typeof addr === 'string'
+        ? 'pipe ' + addr
+        : 'port ' + addr.port;
+      debug('Listening on ' + bind);
+    }
 }

--- a/bootstrap_app.sh
+++ b/bootstrap_app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y htop
+apt-get install -y npm
+curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
+apt-get install -y nodejs
+apt-get install -y wrk

--- a/bootstrap_main.sh
+++ b/bootstrap_main.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y nginx
+apt-get install -y htop
+apt-get install -y wrk
+apt-get install -y haproxy
+
+
+cp /vagrant/default-nginx /etc/nginx/sites-enabled/
+cp /vagrant/haproxy.cfg /etc/haproxy/
+
+systemctl restart nginx
+systemctl restart haproxy

--- a/default-nginx
+++ b/default-nginx
@@ -1,0 +1,15 @@
+# Default server configuration
+#
+
+upstream api_servers {
+    least_conn;
+    server 172.28.128.4:3000;
+    server 172.28.128.5:3010;
+}
+
+server {
+	listen 80 default_server;
+	location / {
+        	proxy_pass http://api_servers;
+    }
+}

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,0 +1,51 @@
+global
+	log /dev/log	local0
+	log /dev/log	local1 notice
+	chroot /var/lib/haproxy
+	stats socket /run/haproxy/admin.sock mode 660 level admin
+	stats timeout 30s
+	user haproxy
+	group haproxy
+	daemon
+
+	# Default SSL material locations
+	ca-base /etc/ssl/certs
+	crt-base /etc/ssl/private
+
+	# Default ciphers to use on SSL-enabled listening sockets.
+	# For more information, see ciphers(1SSL). This list is from:
+	#  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+	ssl-default-bind-options no-sslv3
+
+defaults
+	log	global
+	mode	http
+	option	httplog
+	option	dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
+
+
+frontend app_nodes
+    bind *:80
+    mode http
+    default_backend nodes
+
+backend nodes
+    mode http
+    balance roundrobin
+    option forwardfor
+    http-request set-header X-Forwarded-Port %[dst_port]
+    http-request add-header X-Forwarded-Proto https if { ssl_fc }
+    option httpchk HEAD / HTTP/1.1\r\nHost:localhost
+    server web01 172.28.128.4:3000 check
+    server web02 172.28.128.5:3010 check

--- a/post.lua
+++ b/post.lua
@@ -1,0 +1,3 @@
+wrk.method = "POST"
+wrk.body   = '{"patientId":"100","timestamp":"Tue Nov 01 2016 09:11:51 GMT-0500 (CDT)","medication":"Albuterol"}'
+wrk.headers["Content-Type"] = "application/json"

--- a/routes/api/usages.js
+++ b/routes/api/usages.js
@@ -5,7 +5,7 @@ module.exports = function(app){
         app.usages.push(req.body);
 
         var usageId = app.usages.length;
-        console.log('Stored usage count: ' + usageId);
+        // console.log('Stored usage count: ' + usageId);
 
         res.status(201).json({'id':usageId});
     });


### PR DESCRIPTION
![Speed it up](https://user-images.githubusercontent.com/34496023/33920202-4e26b0ee-df82-11e7-8667-c814d48ed3ae.jpg)


Goal is to get to 1,000,000 requests per second for the endpoint ```/api/usages```

I decided to try out a few scenarios with the following in mind:

1. Any code/config changes that can be made to make things faster.
2. Scale by making a single machine more powerful or/and by adding more machines.
	- Compare Nginx and HAProxy with just default settings. 

### Setup ###
- Scenarios were setup in a ```ubuntu/xenial64``` machine using Vagrant.
- For benchmarking, I went with [wrk](https://github.com/wg/wrk)

In the source directory, run:

```$ vagrant up --provision```

The ```Vagrantfile``` should use ```bootstrap_main.sh``` and ```bootstrap_app.sh``` to configure the machines.

This should set up 3 boxes, ```main```, ```app_server_1``` and ```app_server_2```.

```wrk``` uses a ```lua``` file to configure ```POST``` data. The source directory should contain a file called ```post.lua```.

---

### Experiments ###

#### Scenario 1 ####
- 2 CPU/2048 MB RAM
- No Code Changes
- Running on ```app_server_1``` 
- Server started as: ```npm start```


```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3000/api/usages
Running 30s test @ http://127.0.0.1:3000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   205.19ms   99.49ms 837.37ms   83.18%
    Req/Sec   196.93    100.56   666.00     53.87%
  57948 requests in 30.10s, 12.31MB read
Requests/sec:   1925.12
Transfer/sec:    418.88KB
```

```57948 requests in 30.08s```

#### Scenario 2 ####
- 2 CPU/2048 MB RAM
- Removed ```console.log('Stored usage count: ' + usageId);``` in ```routes/api/usages.js```
- Running on ```app_server_1``` 
- Server started as: ```npm start```

```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3000/api/usages
Running 30s test @ http://127.0.0.1:3000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   140.72ms   52.50ms 820.03ms   81.50%
    Req/Sec   256.31    106.63   666.00     81.42%
  84356 requests in 30.07s, 17.93MB read
Requests/sec:   2805.77
Transfer/sec:    610.66KB
```

```84356 requests in 30.06s```

#### Scenario 3 ####
- 2 CPU/2048 MB RAM
- Running on ```app_server_1```
- start as ```NODE_ENV=production npm start```
- instead of just ```app.use(logger('dev'));``` in ```app.js``` do this:
```
if (app.get('env') === 'development') {
    app.use(logger('dev'));
}
```

```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3000/api/usages
Running 30s test @ http://127.0.0.1:3000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    56.61ms   12.13ms 375.19ms   96.03%
    Req/Sec   589.73    124.16     1.00k    80.73%
  207411 requests in 30.09s, 44.20MB read
Requests/sec:   6892.45
Transfer/sec:      1.47MB
```

```207411 requests in 30.09s```

#### Scenario 4 ####
- 2 CPU/2048 MB RAM
- Running on ```app_server_1```
- start as ```NODE_ENV=production npm start```
- instead of just ```app.use(logger('dev'));``` in ```app.js``` do this:
```
if (app.get('env') === 'development') {
    app.use(logger('dev'));
}
```
- __USE__ Node's cluster [module](https://nodejs.org/dist/latest-v4.x/docs/api/cluster.html) in ```bin/www```

```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3000/api/usages
Running 30s test @ http://127.0.0.1:3000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    42.13ms  105.85ms   2.00s    98.46%
    Req/Sec     1.06k   179.48     3.11k    86.70%
  364621 requests in 30.10s, 77.68MB read
  Socket errors: connect 0, read 0, write 0, timeout 158
Requests/sec:  12114.42
Transfer/sec:      2.58MB
```

```364621 requests in 30.10s```

#### Scenario 5 ####
- 2 CPU/4096 MB RAM
- Running on ```app_server_2```
- start as ```PORT=3010 NODE_ENV=production npm start```
- instead of just ```app.use(logger('dev'));``` in ```app.js``` do this:
```
if (app.get('env') === 'development') {
    app.use(logger('dev'));
}
```
- __USE__ Node's cluster [module](https://nodejs.org/dist/latest-v4.x/docs/api/cluster.html) in ```bin/www```

```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3010/api/usages
Running 30s test @ http://127.0.0.1:3010/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    39.91ms   91.95ms   1.99s    98.75%
    Req/Sec     1.04k   185.74     4.07k    88.73%
  360970 requests in 30.07s, 76.90MB read
  Socket errors: connect 0, read 0, write 0, timeout 167
Requests/sec:  12003.77
Transfer/sec:      2.56MB
```

```360970 requests in 30.10s```

Hmmm... 🤔 

#### Scenario 6 ####
- 4 CPU/4096 MB RAM
- Running on ```app_server_2```
- start as ```PORT=3010 NODE_ENV=production npm start```
- instead of just ```app.use(logger('dev'));``` in ```app.js``` do this:
```
if (app.get('env') === 'development') {
    app.use(logger('dev'));
}
```
- __USE__ Node's cluster [module](https://nodejs.org/dist/latest-v4.x/docs/api/cluster.html) in ```bin/www```

```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:3010/api/usages
Running 30s test @ http://127.0.0.1:3010/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    23.71ms   59.19ms 985.51ms   98.35%
    Req/Sec     1.91k   245.87     4.31k    89.51%
  676530 requests in 30.04s, 144.10MB read
Requests/sec:  22519.71
Transfer/sec:      4.80MB
```

```676530 requests in 30.10s``` - Nice!

Ok - lets run it for a minute. 🎉 


```
ubuntu@ubuntu-xenial:/vagrant$ wrk -t12 -c400 -d60s -s post.lua http://127.0.0.1:3010/api/usages
Running 1m test @ http://127.0.0.1:3010/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    20.29ms   29.04ms   1.03s    97.66%
    Req/Sec     1.86k   339.42     7.00k    86.69%
  1328573 requests in 1.00m, 283.81MB read
Requests/sec:  22108.85
Transfer/sec:      4.72MB
```

```1328573 requests in 1.00m```

Great. 🚀 


#### Scenario 7 ####

Load balancer and proxy in front of two app servers running the same app on two ports.

- Install Nginx (Look in file ```default-nginx``` for conf details). Update the upstream servers in ```default-nginx```. They may not be set to what I have in there. File is copied in ```bootstrap_main.sh```.
__```wrk``` running on host machine.__

```
➜  busyapi-master wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:8000/api/usages
Running 30s test @ http://127.0.0.1:8000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   139.63ms   75.43ms   1.18s    69.29%
    Req/Sec   196.92     75.28   830.00     68.14%
  70339 requests in 30.10s, 17.08MB read
  Socket errors: connect 0, read 1034, write 0, timeout 0
Requests/sec:   2336.97
Transfer/sec:    581.23KB
```

- Install HAProxy
- HAProxy with two app servers. Config in file ```haproxy.cfg```
```
➜  busyapi-master wrk -t12 -c400 -d30s -s post.lua http://127.0.0.1:8000/api/usages
Running 30s test @ http://127.0.0.1:8000/api/usages
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    77.37ms   53.71ms 448.93ms   75.32%
    Req/Sec   340.69    103.67   830.00     73.47%
  122132 requests in 30.08s, 23.29MB read
  Socket errors: connect 0, read 1202, write 0, timeout 0
Requests/sec:   4059.66
Transfer/sec:    792.90KB
```

Both proxies are running on a VM and is adding another layer which would lower speed. But, these three VMs are running
on my laptop with specs:

```
Model Name: MacBook Pro
Model Identifier: MacBookPro13,3
Processor Name: Intel Core i7
Processor Speed: 2.9 GHz
Number of Processors: 1
Total Number of Cores: 4
L2 Cache (per Core): 256 KB
L3 Cache: 8 MB
Memory: 16 GB
```


In a real world application, at a minimum have

1. 2 proxies (HAProxy/Nginx) for redundancy.
2. Each proxy points to 2 application servers. 2 application servers for redundancy.

---

### Takeaway ###

1. Use Node's cluster [module](https://nodejs.org/dist/latest-v4.x/docs/api/cluster.html)
2. Set ```NODE_ENV=production```
3. Check how ```logging``` is done
4. Use ```async```
